### PR TITLE
feat: continue chat via existing file upload

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -13,29 +13,33 @@ const chatLog = [];
 let first_person = '';
 let second_person = '';
 let current_person = '';
-let fileChoosen = '';
+let fileChosen = '';
 
-rl.question('Continue from previous chat? Y/N :', (cont) => {
-	if (cont === "Y" || cont === "y) {
+rl.question('Continue from previous chat? y/N: ', (cont) => {
+	if (cont === "Y" || cont === "y") {
 		chatLog.push("  \n");
-	    
+
 		const files = fs.readdirSync(path.join(__dirname)).filter((filename) => filename.includes(".md") && !filename.includes("README"));
 
-		if (files.length === 0) {console.log("No Files Available")}
-		
-		let iterator = 0;	
+		if (files.length === 0) {
+			console.log("No Files Available");
+			rl.close();
+			return;
+		}
+
+		let iterator = 0;
 		files.forEach((File1) => {
 			console.log(File1, iterator);
 			iterator++;
 		})
-		
+
 		rl.question("Please choose a file, choose by the number next to the file: ", (itera) => {
-			fileChoosen = files[itera];
-			fs.readFile(fileChoosen, 'utf-8',(err, data) => {
+			fileChosen = files[itera];
+			fs.readFile(fileChosen, 'utf-8',(err, data) => {
 				data = data.split("\n");
-				
+
 				if (err) {
-					throw err;	
+					throw err;
 				}
 
 				try {
@@ -47,9 +51,7 @@ rl.question('Continue from previous chat? Y/N :', (cont) => {
 					console.log("Log unfinished, or log is not accessible. The log either has only 1 persons input or it has been most likely corrupted.")
 					rl.close();
 				}
-			
 			});
-			
 		});
 
 	} else {
@@ -61,7 +63,6 @@ rl.question('Continue from previous chat? Y/N :', (cont) => {
 				chat();
 			});
 		});
-
 	}
 });
 
@@ -69,9 +70,9 @@ function chatCont() {
 	rl.question(`${current_person}: `, (message) => {
 		if (message === "byebye") {
 			const data = chatLog.join("");
-			fs.appendFileSync(fileChoosen, data);
-			console.log(`wrote to file ${fileChoosen}`);
-			rl.close()	
+			fs.appendFileSync(fileChosen, data);
+			console.log(`wrote to file ${fileChosen}`);
+			rl.close()
 
 		} else {
 			chatLog.push(`**${current_person}**: ${message}`);
@@ -99,7 +100,7 @@ function chat() {
             rl.close();
         } else {
             chatLog.push(`**${current_person}**: ${message}`);
-           	chatLog.push("  \n"); 
+           	chatLog.push("  \n");
 			current_person = current_person === first_person ? second_person : first_person;
             chat();
         }

--- a/chat.js
+++ b/chat.js
@@ -2,6 +2,7 @@
 
 const readline = require('readline');
 const fs = require('fs');
+const path = require('path');
 
 const rl = readline.createInterface({
     input: process.stdin,
@@ -12,35 +13,95 @@ const chatLog = [];
 let first_person = '';
 let second_person = '';
 let current_person = '';
+let fileChoosen = '';
 
-rl.question('Enter first person name: ', (name1) => {
-    first_person = name1;
-    rl.question('Enter second person name: ', (name2) => {
-        second_person = name2;
-        current_person = first_person;
-        chat();
-    });
+rl.question('Continue from previous chat? y/n :', (cont) => {
+	if (cont === "y") {
+		
+		const files = fs.readdirSync(path.join(__dirname)).filter((filename) => filename.includes(".md") && !filename.includes("README"));
+
+		if (files.length === 0) {console.log("No Files Available")}
+		
+		let iterator = 0;	
+		files.forEach((File1) => {
+			console.log(File1, iterator);
+			iterator++;
+		})
+		
+		rl.question("Please choose a file, choose by the number next to the file: ", (itera) => {
+			fileChoosen = files[itera];
+			fs.readFile(fileChoosen, 'utf-8',(err, data) => {
+				data = data.split("\n");
+				
+				if (err) {
+					throw err;	
+				}
+
+				try {
+					first_person = data[0].split(":")[0].replaceAll("*", "");
+					second_person = data[1].split(":")[0].replaceAll("*", "");
+					current_person = first_person;
+					chatCont();
+				} catch {
+					console.log("Log unfinished, or log is not accessible. The log either has only 1 persons input or it has been most likely corrupted.")
+					rl.close();
+				}
+			
+			});
+			
+		});
+
+	} else {
+		rl.question('Enter first person name: ', (name1) => {
+			first_person = name1;
+			rl.question('Enter second person name: ', (name2) => {
+				second_person = name2;
+				current_person = first_person;
+				chat();
+			});
+		});
+
+	}
 });
+
+function chatCont() {
+	rl.question(`${current_person}: `, (message) => {
+		if (message === "byebye") {
+			const data = chatLog.join("");
+			fs.appendFileSync(fileChoosen, data);
+			console.log(`wrote to file ${fileChoosen}`);
+			rl.close()	
+
+		} else {
+			chatLog.push(`**${current_person}**: ${message}`);
+			chatLog.push("  \n");
+			current_person = current_person === first_person ? second_person : first_person;
+			chatCont();
+		}
+	});
+}
 
 function chat() {
     rl.question(`${current_person}: `, (message) => {
         if (message.toLowerCase() === 'byebye') {
-            const date = new Date();
+			const date = new Date();
             const dateString = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
             const filename = `${first_person}-${second_person}-chatlog-${dateString}.md`;
-            const data = chatLog.join('  \n');  // added two spaces before the line break
+            const data = chatLog.join('');  // added two spaces before the line break
             fs.writeFile(filename, data, 'utf8', function(err) {
                 if (err) {
                     console.log('An error occured while writing to file');
                     return;
                 }
-                console.log(`Chat log saved to file: ${filename}`);
+				console.log(`Chat log saved to file: ${filename}`);
             });
             rl.close();
         } else {
             chatLog.push(`**${current_person}**: ${message}`);
-            current_person = current_person === first_person ? second_person : first_person;
+           	chatLog.push("  \n"); 
+			current_person = current_person === first_person ? second_person : first_person;
             chat();
         }
     });
 }
+

--- a/chat.js
+++ b/chat.js
@@ -15,8 +15,8 @@ let second_person = '';
 let current_person = '';
 let fileChoosen = '';
 
-rl.question('Continue from previous chat? y/n :', (cont) => {
-	if (cont === "y") {
+rl.question('Continue from previous chat? Y/N :', (cont) => {
+	if (cont === "Y") || (cont === "y) {
 		
 		const files = fs.readdirSync(path.join(__dirname)).filter((filename) => filename.includes(".md") && !filename.includes("README"));
 

--- a/chat.js
+++ b/chat.js
@@ -17,7 +17,8 @@ let fileChoosen = '';
 
 rl.question('Continue from previous chat? Y/N :', (cont) => {
 	if (cont === "Y" || cont === "y) {
-		
+		chatLog.push("  \n");
+	    
 		const files = fs.readdirSync(path.join(__dirname)).filter((filename) => filename.includes(".md") && !filename.includes("README"));
 
 		if (files.length === 0) {console.log("No Files Available")}

--- a/chat.js
+++ b/chat.js
@@ -16,7 +16,7 @@ let current_person = '';
 let fileChoosen = '';
 
 rl.question('Continue from previous chat? Y/N :', (cont) => {
-	if (cont === "Y") || (cont === "y) {
+	if (cont === "Y" || cont === "y) {
 		
 		const files = fs.readdirSync(path.join(__dirname)).filter((filename) => filename.includes(".md") && !filename.includes("README"));
 


### PR DESCRIPTION
In the issues for this repo, a feature to continue a previous chat was discussed. This implements that feature.

Asks if they would like to continue chat, then shows them possible chat files to continue. Then gets the names from the chat files without user input and continues the conversation appending to that choosen file.